### PR TITLE
Add .claude subdirectories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 .config/iterm2
 .config/raycast
 .config/github-copilot
+.claude/ide/
+.claude/projects/
+.claude/statsig/
+.claude/todos/


### PR DESCRIPTION
## Summary
- .claude/ide/, .claude/projects/, .claude/statsig/, .claude/todos/ を .gitignore に追加
- ローカルのClaude設定ファイルがリポジトリに含まれないようにする

## Test plan
- [ ] .gitignore に追加されたディレクトリが正しく無視されることを確認
- [ ] git status で.claudeサブディレクトリが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)