### PR TITLE
Update work project path to use ghq directory structure

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -18,5 +18,5 @@
 	gpgsign = false
 
 # Override for work projects
-[includeIf "gitdir:~/projects/tsumikiinc/**/"]
+[includeIf "gitdir:~/ghq/github.com/tsumikiinc/**/"]
   path = ~/.gitconfig-work


### PR DESCRIPTION
## Summary
- Updated the includeIf gitdir path in .gitconfig from `~/projects/tsumikiinc/` to `~/ghq/github.com/tsumikiinc/`
- This change aligns with the ghq directory structure for managing Git repositories

## Test plan
- [ ] Verify that Git configuration properly applies work email for repositories under `~/ghq/github.com/tsumikiinc/`
- [ ] Confirm that personal email is still used for other repositories

🤖 Generated with [Claude Code](https://claude.ai/code)