### PR TITLE
Change cg alias to use cursor instead of code

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -122,7 +122,7 @@ command -v mise >/dev/null 2>&1 && eval "$(mise activate zsh)"
 export TERM=xterm-256color
 
 # for ghq
-alias cg='code "`ghq root`/`ghq list | fzf`"'
+alias cg='cursor "`ghq root`/`ghq list | fzf`"'
 
 case ${OSTYPE} in
   darwin*)


### PR DESCRIPTION
## Summary
- ghqで管理されているリポジトリを開くエイリアス`cg`をVS Codeからcursorに変更

## Test plan
- [ ] .zshrcを読み込んでcgコマンドが正常に動作することを確認
- [ ] ghq list | fzfで選択したリポジトリがcursorで開かれることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)