### PR TITLE
Add voice notification hook for Claude Code task completion

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,5 +11,18 @@
       "Bash(ls:*)"
     ],
     "deny": []
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "say \"Claude Codeがタスクを完了しました\""
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Claude Code設定にhooksセクションを追加
- タスク完了時にmacOSのsayコマンドで音声通知を行う機能を追加

## Test plan
- [ ] Claude Codeでタスクを実行し、完了時に音声通知が鳴ることを確認
- [ ] 設定ファイルのJSON構文が正しいことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)