### PR TITLE
Add notification hook configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,17 @@
           }
         ]
       }
+    ],
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "say \"Claude Codeからの通知があります\""
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary  
- Add notification hook with macOS say command
- Provides audio feedback for Claude Code notifications

## Test plan
- [x] Verify hook configuration syntax
- [x] Confirm say command works on macOS

🤖 Generated with [Claude Code](https://claude.ai/code)