### PR TITLE
Add credential files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 .config/gcloud
 .config/iterm2
 .config/raycast
+.config/gh/hosts.yml
 .config/github-copilot
 .claude/ide/
 .claude/projects/
 .claude/statsig/
 .claude/todos/
+.claude/.credentials.json


### PR DESCRIPTION
## Summary
- Add `.claude/.credentials.json` to .gitignore
- Add `.config/gh/hosts.yml` to .gitignore
- Prevent committing sensitive credential information

## Test plan
- [x] Verify that `.gitignore` includes the new credential file paths
- [ ] Confirm that git no longer tracks these files
- [ ] Ensure no sensitive information is exposed in the repository

🤖 Generated with [Claude Code](https://claude.ai/code)