### PR TITLE
Remove .config/gh/hosts.yml from git tracking

### DIFF
--- a/.config/gh/hosts.yml
+++ b/.config/gh/hosts.yml
@@ -1,5 +1,0 @@
-github.com:
-  git_protocol: ssh
-  users:
-    karia:
-  user: karia


### PR DESCRIPTION
## Summary
- Remove `.config/gh/hosts.yml` from git tracking to properly apply gitignore rules
- The file was already tracked before being added to .gitignore

## Test plan
- [x] Verify that `.config/gh/hosts.yml` is removed from the repository
- [x] Confirm that future changes to the file won't be tracked by git
- [x] Ensure the file still exists locally but is ignored by git

🤖 Generated with [Claude Code](https://claude.ai/code)