### PR TITLE
Make Claude Code hooks cross-platform compatible

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "say \"Claude Codeがタスクを完了しました\""
+            "command": "if [[ \"$(uname)\" == \"Darwin\" ]]; then say \"Claude Codeがタスクを完了しました\"; fi"
           }
         ]
       }
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "say \"Claude Codeからの通知があります\""
+            "command": "if [[ \"$(uname)\" == \"Darwin\" ]]; then say \"Claude Codeからの通知があります\"; fi"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Add platform detection to prevent `say` command errors on non-macOS systems
- Wrap `say` commands in conditional checks that only execute on Darwin (macOS)
- Maintains existing functionality on macOS while preventing errors on Linux/WSL

## Test plan
- [ ] Verify hooks execute without errors on Linux/WSL
- [ ] Confirm `say` commands still work on macOS
- [ ] Check that Claude Code hooks complete successfully on both platforms

🤖 Generated with [Claude Code](https://claude.ai/code)