### PR TITLE
Add additional permissions to Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,9 @@
 {
   "permissions": {
     "allow": [
+      "Bash(brew list:*)",
+      "Bash(cat:*)",
+      "Bash(echo $PATH)",
       "Bash(gh pr create:*)",
       "Bash(gh pr edit:*)",
       "Bash(git add:*)",
@@ -8,7 +11,13 @@
       "Bash(git commit:*)",
       "Bash(git pull:*)",
       "Bash(git push:*)",
-      "Bash(ls:*)"
+      "Bash(ls:*)",
+      "Bash(mise ls:*)",
+      "Bash(mise list:*)",
+      "Bash(mkdir:*)",
+      "Bash(pinact:*)",
+      "Bash(pre-commit run:*)",
+      "Bash(yamllint:*)"
     ],
     "deny": []
   },


### PR DESCRIPTION
## Summary
- Added new permitted commands to `.claude/settings.json` for enhanced development capabilities
- Includes commands for package management, file operations, and development tools

## Changes
- `brew list`: Check installed packages on macOS
- `cat`: Read file contents
- `echo $PATH`: Check PATH environment variable
- `mise ls/list`: Manage development tool versions
- `mkdir`: Create directories
- `pinact`: Use pinact tool
- `pre-commit run`: Run pre-commit hooks
- `yamllint`: Validate YAML files

## Test plan
- [x] Pre-commit hooks passed automatically
- [ ] Verify Claude Code can use the newly permitted commands
- [ ] Ensure no security implications from the added permissions

🤖 Generated with [Claude Code](https://claude.ai/code)