### PR TITLE
Fix gh credential helper path for cross-platform compatibility

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -10,10 +10,10 @@
 	defaultBranch = main
 [credential "https://github.com"]
 	helper =
-	helper = !/usr/bin/gh auth git-credential
+	helper = !gh auth git-credential
 [credential "https://gist.github.com"]
 	helper =
-	helper = !/usr/bin/gh auth git-credential
+	helper = !gh auth git-credential
 [commit]
 	gpgsign = false
 


### PR DESCRIPTION
## Summary
- Remove absolute path `/usr/bin/` from gh credential helper configuration
- Make git config work across different platforms where gh may be installed in different locations
- Change from `\!/usr/bin/gh` to `\!gh` for both github.com and gist.github.com credentials

## Test plan
- [ ] Verify gh credential helper works on macOS where gh is installed via Homebrew
- [ ] Verify gh credential helper works on Linux where gh may be in different PATH locations
- [ ] Test git push/pull operations with GitHub authentication

🤖 Generated with [Claude Code](https://claude.ai/code)