### PR TITLE
Add open command permission to Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,7 @@
       "Bash(mise ls:*)",
       "Bash(mise list:*)",
       "Bash(mkdir:*)",
+      "Bash(open:*)",
       "Bash(pinact:*)",
       "Bash(pre-commit run:*)",
       "Bash(yamllint:*)"
@@ -47,5 +48,8 @@
         ]
       }
     ]
+  },
+  "feedbackSurveyState": {
+    "lastShownTime": 1754061737663
   }
 }


### PR DESCRIPTION
## Summary
- Add `Bash(open:*)` to permissions allow list in `.claude/settings.json`

🤖 Generated with [Claude Code](https://claude.ai/code)