### PR TITLE
Add .claude/shell-snapshots/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .claude/statsig/
 .claude/todos/
 .claude/.credentials.json
+.claude/shell-snapshots/


### PR DESCRIPTION
## Summary
- Add .claude/shell-snapshots/ directory to .gitignore

## Test plan
- Verified that .gitignore properly excludes the directory

🤖 Generated with [Claude Code](https://claude.ai/code)