### PR TITLE
Set up pnpm via mise and load PATH conditionally

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -9,6 +9,7 @@ node = "lts"
 "npm:prh" = "latest"
 "npm:prh-languageserver" = "latest"
 pinact = "latest"
+pnpm = "latest"
 uv = "latest"
 
 [settings]

--- a/.zshrc
+++ b/.zshrc
@@ -164,3 +164,13 @@ source_if_exists "${HOME}/.iterm2_shell_integration.zsh"
 
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 source_if_exists "${HOME}/.p10k.zsh"
+
+# pnpm
+if command -v pnpm >/dev/null 2>&1; then
+  export PNPM_HOME="${HOME}/Library/pnpm"
+  case ":$PATH:" in
+    *":$PNPM_HOME:"*) ;;
+    *) export PATH="$PNPM_HOME:$PATH" ;;
+  esac
+fi
+# pnpm end


### PR DESCRIPTION
## Summary

- Add `pnpm = "latest"` to global mise config so pnpm is provisioned consistently
- Wrap pnpm PATH setup in `command -v pnpm` check (matches mise/anyenv/direnv style)
- Replace hard-coded `/Users/...` with `${HOME}/...`

## Test plan

- [ ] `mise install` provisions pnpm
- [ ] Open a new shell on a host with pnpm installed and confirm `$PNPM_HOME` is set and on `$PATH`
- [ ] Open a new shell on a host without pnpm and confirm no errors and `$PNPM_HOME` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)