### PR TITLE
switch git hook runner from pre-commit to prek

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-pre-commit = "latest"
+prek = "latest"


### PR DESCRIPTION
Replace `pre-commit` with `prek` in global mise tool config.