### PR TITLE
remove gemini and github copilot from mise config

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,10 +1,8 @@
 [tools]
 claude = "latest"
 fzf = "latest"
-gemini = "latest"
 ghq = "latest"
 node = "lts"
-"npm:@github/copilot" = "latest"
 "npm:@openai/codex" = "latest"
 "npm:prh" = "latest"
 "npm:prh-languageserver" = "latest"


### PR DESCRIPTION
Remove unused tools from mise config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)