### PR TITLE
fix pnpm installation by switching to npm backend

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -7,7 +7,7 @@ node = "lts"
 "npm:prh" = "latest"
 "npm:prh-languageserver" = "latest"
 pinact = "latest"
-pnpm = "latest"
+"npm:pnpm" = "latest"
 uv = "latest"
 
 [settings]


### PR DESCRIPTION
## Summary

- `pnpm = "latest"` だと aqua バックエンドが使われるが、aqua-registry の定義が古く `pnpm-linux-x64`（拡張子なし）を探してしまいインストールに失敗する
- `npm:pnpm` に変更することで npm バックエンドを使うよう明示し、問題を回避

## Test plan

- [ ] `mise up` でエラーなく pnpm がインストールされること