### PR TITLE
remove npm-global PATH as it is no longer needed

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -151,9 +151,6 @@ if [[ -f "/home/linuxbrew/.linuxbrew/bin/brew" ]]; then eval "$(/home/linuxbrew/
 # snap
 add_path_if_exists "/snap/bin"
 
-# npm
-add_path_if_exists "${HOME}/.npm-global/bin"
-
 # The next line updates PATH for the Google Cloud SDK.
 source_if_exists "${HOME}/projects/others/google-cloud-sdk/path.zsh.inc"
 


### PR DESCRIPTION
## Summary

- mise で管理外だった `~/.npm-global` を削除したため、PATH への追加も不要になった
- `.zshrc` から `~/.npm-global/bin` の PATH 設定を削除

## Test plan

- [ ] 新しいシェルセッションで `which claude` が mise 経由を指すこと