### PR TITLE
ignore mimeapps.list and sort mise config tools alphabetically

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -4,10 +4,10 @@ fzf = "latest"
 ghq = "latest"
 node = "lts"
 "npm:@openai/codex" = "latest"
+"npm:pnpm" = "latest"
 "npm:prh" = "latest"
 "npm:prh-languageserver" = "latest"
 pinact = "latest"
-"npm:pnpm" = "latest"
 uv = "latest"
 
 [settings]

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 .config/configstore/
 .claude/mcp-needs-auth-cache.json
 .config/ookla/
+.config/mimeapps.list


### PR DESCRIPTION
## Summary

- `.config/mimeapps.list` を `.gitignore` に追加（Claude Code が自動生成する環境固有ファイル）
- `.config/mise/config.toml` のツール一覧をアルファベット順にソート