### PR TITLE
Fix Claude Code settings and add statusline command

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,4 @@
 {
-  "env": {
-    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
-  },
   "permissions": {
     "allow": [
       "Bash(actionlint:*)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -56,6 +56,7 @@
       "Bash(git push -f:*)"
     ]
   },
+  "model": "opus",
   "hooks": {
     "Stop": [
       {
@@ -80,10 +81,16 @@
       }
     ]
   },
-  "feedbackSurveyState": {
-    "lastShownTime": 1754061737663
+  "statusLine": {
+    "type": "command",
+    "command": "bash /home/karia/.claude/statusline-command.sh"
   },
   "enabledPlugins": {
     "superpowers@claude-plugins-official": true
+  },
+  "effortLevel": "high",
+  "agentPushNotifEnabled": true,
+  "feedbackSurveyState": {
+    "lastShownTime": 1754061737663
   }
 }

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+input=$(cat)
+user=$(whoami)
+host=$(hostname -s)
+cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd')
+model=$(echo "$input" | jq -r '.model.display_name // empty')
+used=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+
+line="${user}@${host} ${cwd}"
+[ -n "$model" ] && line="${line} | ${model}"
+[ -n "$used" ] && line="${line} [context: $(printf '%.0f' "$used")%]"
+
+printf '%s' "$line"


### PR DESCRIPTION
## Summary

- Add a custom statusline command script (`.claude/statusline-command.sh`)
- Invoke the statusline script via `bash` instead of `zsh` so shellcheck passes
- Adjust Claude Code settings (model, effortLevel, agentPushNotifEnabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)