### PR TITLE
Use tilde path for statusline command

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -83,7 +83,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "bash /home/karia/.claude/statusline-command.sh"
+    "command": "bash ~/.claude/statusline-command.sh"
   },
   "enabledPlugins": {
     "superpowers@claude-plugins-official": true


### PR DESCRIPTION
The statusline command was hardcoded to `/home/karia`, which breaks on machines with a different home directory. Use `~` so it works everywhere.