### PR TITLE
Clean up version manager initialization in .zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -116,9 +116,6 @@ setopt print_eightbit
 export EDITOR='vim'
 #export SHELL='zsh'
 
-# for mise
-command -v mise >/dev/null 2>&1 && eval "$(mise activate zsh)"
-
 export TERM=xterm-256color
 
 # for ghq
@@ -168,3 +165,6 @@ if command -v pnpm >/dev/null 2>&1; then
   esac
 fi
 # pnpm end
+
+# for mise
+command -v mise >/dev/null 2>&1 && eval "$(mise activate zsh)"

--- a/.zshrc
+++ b/.zshrc
@@ -126,9 +126,6 @@ alias cg='code "`ghq root`/`ghq list | fzf`"'
 
 case ${OSTYPE} in
   darwin*)
-    # for anyenv
-    command -v anyenv >/dev/null 2>&1 && eval "$(anyenv init -)"
-
     # for direnv
     command -v direnv >/dev/null 2>&1 && eval "$(direnv hook zsh)"
 


### PR DESCRIPTION
Remove anyenv initialization (migrated to mise) and move mise activation to the end of the file so it runs after other path setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)