### PR TITLE
Ignore .claude/.last-cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .config/gh/hosts.yml
 .config/github-copilot
 .claude/.update.lock
+.claude/.last-cleanup
 .claude/backups/
 .config/Code/
 .config/go/


### PR DESCRIPTION
Add `.claude/.last-cleanup` to `.gitignore`; it is a local Claude Code state file that should not be tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)