### PR TITLE
Show ccusage statusline on second line

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -13,12 +13,16 @@ else
 fi
 
 if [ -n "$usage" ]; then
-  line="${line} | ${usage}"
+  second="${usage}"
 else
   model=$(echo "$input" | jq -r '.model.display_name // empty')
   used=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
-  [ -n "$model" ] && line="${line} | ${model}"
-  [ -n "$used" ] && line="${line} [context: $(printf '%.0f' "$used")%]"
+  [ -n "$model" ] && second="${model}"
+  [ -n "$used" ] && second="${second} [context: $(printf '%.0f' "$used")%]"
 fi
 
-printf '%s' "$line"
+if [ -n "$second" ]; then
+  printf '%s\n%s' "$line" "$second"
+else
+  printf '%s' "$line"
+fi


### PR DESCRIPTION
The single statusline was too long. Move the ccusage output (and the model/context fallback) to a second line, keeping `user@host cwd` on the first line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)