### PR TITLE
Add .zshenv with mise shims for non-interactive sessions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: v0.10.0.1
     hooks:
       - id: shellcheck
-        exclude: \.zshrc$
+        exclude: \.zsh(rc|env)$
   - repo: https://github.com/google/yamlfmt
     rev: v0.13.0
     hooks:

--- a/.zshenv
+++ b/.zshenv
@@ -1,0 +1,5 @@
+# mise: shims activation for non-interactive sessions (Claude Code, scripts, cron, etc.)
+# Interactive sessions use PATH-based activation via `mise activate zsh` in .zshrc
+if [[ ! -o interactive ]]; then
+  command -v mise >/dev/null 2>&1 && eval "$(mise activate --shims)"
+fi


### PR DESCRIPTION
## Summary
- Add `.zshenv` that activates mise shims (`mise activate --shims`) for non-interactive sessions only
- This makes mise-managed tools (terraform, tflint, etc.) available in Claude Code, scripts, and cron jobs
- Interactive sessions continue to use PATH-based activation (`mise activate zsh`) from `.zshrc`
- Exclude `.zshenv` from shellcheck in pre-commit config (same treatment as `.zshrc`)

## Setup
```
ln -s ~/ghq/github.com/karia/dot-files/.zshenv ~/.zshenv
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)