### PR TITLE
Restore default TUI renderer

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -90,7 +90,6 @@
     "frontend-design@claude-plugins-official": true
   },
   "effortLevel": "high",
-  "tui": "fullscreen",
   "agentPushNotifEnabled": true,
   "feedbackSurveyState": {
     "lastShownTime": 1754061737663


### PR DESCRIPTION
Remove the `tui: fullscreen` setting so Claude Code falls back to the default renderer.

The fullscreen alt-screen renderer breaks tmux copy-mode scrollback (the alt-screen has no scrollback history) and causes paste garbling over tmux.