### PR TITLE
Enable input needed notification in Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -93,5 +93,6 @@
   "agentPushNotifEnabled": true,
   "feedbackSurveyState": {
     "lastShownTime": 1754061737663
-  }
+  },
+  "inputNeededNotifEnabled": true
 }


### PR DESCRIPTION
Enable `inputNeededNotifEnabled` so Claude Code sends a notification when it is waiting for input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)