### PR TITLE
Add herdr config

### DIFF
--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -1,0 +1,20 @@
+onboarding = false
+[keys]
+prefix = "ctrl+z"
+
+# pane 移動: hjkl に加えて上下左右の矢印キーも有効化（tmux 風）
+focus_pane_left  = ["prefix+h", "prefix+left"]
+focus_pane_down  = ["prefix+j", "prefix+down"]
+focus_pane_up    = ["prefix+k", "prefix+up"]
+focus_pane_right = ["prefix+l", "prefix+right"]
+
+# workspace navigate（prefix+w 後）: up/down に加えて j/k も有効化
+navigate_workspace_up   = ["up", "k"]
+navigate_workspace_down = ["down", "j"]
+
+[theme]
+name = "catppuccin-latte"
+auto_switch = false
+
+[ui]
+agent_panel_sort = "spaces"

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@
 .claude/mcp-needs-auth-cache.json
 .config/ookla/
 .config/mimeapps.list
+.config/herdr/*.log
+.config/herdr/*.sock
+.config/herdr/session.json


### PR DESCRIPTION
Track herdr's config.toml. Keybindings enable arrow keys alongside hjkl for pane focus, and j/k alongside up/down for the workspace picker (prefix+w).

Also gitignore herdr runtime files (logs, sockets, session.json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)