### PR TITLE
Add Ghostty config and let herdr follow terminal colors

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -1,0 +1,1 @@
+theme = GitHub Dark Default

--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -13,7 +13,7 @@ navigate_workspace_up   = ["up", "k"]
 navigate_workspace_down = ["down", "j"]
 
 [theme]
-name = "catppuccin-latte"
+name = "terminal"
 auto_switch = false
 
 [ui]


### PR DESCRIPTION
Add a Ghostty config with the GitHub Dark Default theme, and switch herdr's theme to `terminal` so its UI follows Ghostty's ANSI palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)