### PR TITLE
Enable OS notifications for agent completion in herdr

### DIFF
--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -18,3 +18,7 @@ auto_switch = false
 
 [ui]
 agent_panel_sort = "spaces"
+
+# エージェント完了を OS 通知で受け取る
+[ui.toast]
+delivery = "system"


### PR DESCRIPTION
Set `[ui.toast] delivery = "system"` so herdr sends a macOS notification when an agent finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)