### PR TITLE
Set Ghostty font to UDEV Gothic 35NF and restore window state

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -1,1 +1,2 @@
 theme = GitHub Dark Default
+font-family = "UDEV Gothic 35NF"

--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -1,2 +1,5 @@
 theme = GitHub Dark Default
 font-family = "UDEV Gothic 35NF"
+
+# 前回終了時のウィンドウ位置・サイズ・タブ/split を復元（macOS 専用）
+window-save-state = always


### PR DESCRIPTION
Switch Ghostty to a Japanese Nerd Font so CJK glyphs no longer fall back to a mismatched system font, and remember the window size/position across restarts.

- `font-family = "UDEV Gothic 35NF"`: unifies Latin, Japanese, and Nerd Font icons in one family; the `35` variant widens half-width chars for looser spacing
- `window-save-state = always`: restore position/size/tabs/splits on relaunch (macOS)

Requires the `font-udev-gothic-nf` cask installed locally.