### PR TITLE
Improve ghostty font rendering on non-retina displays

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -1,5 +1,9 @@
 theme = GitHub Dark Default
-font-family = "UDEV Gothic 35NF"
+font-family = "UDEV Gothic NF"
+
+# 非Retina/等倍ディスプレイでのフォント細り・潰れ対策（macOS 専用）
+font-thicken = true
+font-thicken-strength = 128
 
 # 前回終了時のウィンドウ位置・サイズ・タブ/split を復元（macOS 専用）
 window-save-state = always


### PR DESCRIPTION
Fonts looked thin/crushed in ghostty on a non-HiDPI (1x) external display.

- Enable `font-thicken` with strength 128
- Switch `font-family` to standard-width `UDEV Gothic NF` (was `35NF` narrow variant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)