### PR TITLE
Define helper functions in both .zshenv and .zshrc

### DIFF
--- a/.zshenv
+++ b/.zshenv
@@ -4,7 +4,8 @@
 # Put PATH and environment settings here so tools resolve even when
 # .zshrc (interactive-only) and .zprofile (login-only) are NOT sourced.
 
-# shared helpers (also used by .zshrc)
+# shared helpers -- intentionally duplicated in .zshrc so each file
+# works standalone even when the other is missing (e.g. symlink not created)
 source_if_exists() { [[ -f "$1" ]] && source "$1"; }
 add_path_if_exists() { [[ -d "$1" ]] && export PATH="$1:${PATH}"; }
 

--- a/.zshrc
+++ b/.zshrc
@@ -1,7 +1,11 @@
 #!/bin/zsh
 # Interactive-only settings. PATH and environment live in .zshenv
 # (which is sourced for every shell, including non-interactive ones).
-# Helper functions source_if_exists / add_path_if_exists are defined there.
+
+# shared helpers -- intentionally duplicated in .zshenv so each file
+# works standalone even when the other is missing (e.g. symlink not created)
+source_if_exists() { [[ -f "$1" ]] && source "$1"; }
+add_path_if_exists() { [[ -d "$1" ]] && export PATH="$1:${PATH}"; }
 
 # plugin manager
 


### PR DESCRIPTION
## Why

`.zshrc` calls `source_if_exists` but its definition lived only in `.zshenv`. On a machine where the `~/.zshenv` symlink was never created (e.g. WSL2 set up before `.zshenv` was added), zsh startup failed with `command not found: source_if_exists`.

## What

Duplicate the two one-line helpers in both files (with comments noting the intentional duplication) so each file works standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)