### PR TITLE
Move pnpm PATH setup to .zshenv for non-interactive shells

### DIFF
--- a/.zshenv
+++ b/.zshenv
@@ -50,8 +50,11 @@ if [[ -z "$__ZSHENV_SETUP_DONE" ]]; then
   # pnpm: global bin for CLIs installed via `pnpm add -g` / `pnpm link --global`.
   # `pnpm setup` writes this to .zshrc, but keep it here so non-interactive
   # shells (Claude Code, hooks) also resolve globally-installed commands.
-  export PNPM_HOME="${HOME}/Library/pnpm"
-  add_path_if_exists "$PNPM_HOME/bin"
+  # Only set it where the global bin actually exists (same shape as Go above).
+  if [[ -d "${HOME}/Library/pnpm/bin" ]]; then
+    export PNPM_HOME="${HOME}/Library/pnpm"
+    export PATH="$PNPM_HOME/bin:$PATH"
+  fi
 
   # mise: shims for non-interactive shells (scripts, hooks, Claude Code, cron).
   # Interactive shells use `mise activate zsh` (function mode) in .zshrc.

--- a/.zshenv
+++ b/.zshenv
@@ -47,6 +47,12 @@ if [[ -z "$__ZSHENV_SETUP_DONE" ]]; then
   # Google Cloud SDK PATH (completion stays in .zshrc -- interactive only)
   source_if_exists "${HOME}/projects/others/google-cloud-sdk/path.zsh.inc"
 
+  # pnpm: global bin for CLIs installed via `pnpm add -g` / `pnpm link --global`.
+  # `pnpm setup` writes this to .zshrc, but keep it here so non-interactive
+  # shells (Claude Code, hooks) also resolve globally-installed commands.
+  export PNPM_HOME="${HOME}/Library/pnpm"
+  add_path_if_exists "$PNPM_HOME/bin"
+
   # mise: shims for non-interactive shells (scripts, hooks, Claude Code, cron).
   # Interactive shells use `mise activate zsh` (function mode) in .zshrc.
   if [[ ! -o interactive ]]; then


### PR DESCRIPTION
`pnpm setup` writes its PATH block to `.zshrc` (interactive-only), so non-interactive shells (Claude Code, hooks) could not resolve globally-installed CLIs.

The block was dropped from `.zshrc` in the Jul 3 env consolidation (9ef1da8 / c3b7c4e) but never moved to `.zshenv`. This restores it in `.zshenv` using the existing `add_path_if_exists` helper so it also adapts to environments where pnpm is not installed.