### PR TITLE
Add herdr to global mise tools

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -2,6 +2,7 @@
 claude = "latest"
 fzf = "latest"
 ghq = "latest"
+herdr = "latest"
 node = "lts"
 "npm:@openai/codex" = "latest"
 "npm:ccusage" = "latest"


### PR DESCRIPTION
Install [herdr](https://herdr.dev/) (agent multiplexer) globally via mise. Config already exists at `.config/herdr/config.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)