### PR TITLE
Remove pinned model setting from Claude Code config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -56,7 +56,6 @@
       "Bash(git push -f:*)"
     ]
   },
-  "model": "claude-fable-5[1m]",
   "hooks": {
     "Stop": [
       {


### PR DESCRIPTION
Stop pinning `model` in settings.json; rely on the CLI/mise default instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)