### PR TITLE
Ignore local secrets and runtime files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .claude/policy-limits.json
 .claude/projects/
 .claude/remote-settings.json
+.claude/scheduled_tasks.lock
 .claude/session-env/
 .claude/sessions/
 .claude/settings.local.json
@@ -23,13 +24,16 @@
 .claude/tasks/
 .claude/telemetry/
 .claude/todos/
+.claude/uploads/
 .config/Code/
+.config/cloudflare/
 .config/configstore/
 .config/gcloud
 .config/gh/hosts.yml
 .config/github-copilot
 .config/go/
 .config/google-chrome-for-testing/
+.config/helm/
 .config/herdr/*.log
 .config/herdr/*.sock
 .config/herdr/session.json
@@ -37,6 +41,7 @@
 .config/mimeapps.list
 .config/ookla/
 .config/raycast
+.config/tailscale/
 .config/wslu/
 .gitconfig-work
 credentials.json


### PR DESCRIPTION
`.config/cloudflare/` (API tokens), `.config/helm/`, `.config/tailscale/`, `.claude/uploads/`, and `.claude/scheduled_tasks.lock` were untracked but not ignored, so a careless `git add -A` could commit plaintext secrets. Add them to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeYbRTirCPm53VRANcrfyC