### PR TITLE
Migrate local checkout to ghq; track herdr skill symlink

### DIFF
--- a/.claude/skills/herdr/SKILL.md
+++ b/.claude/skills/herdr/SKILL.md
@@ -1,0 +1,1 @@
+/home/karia/ghq/github.com/ogulcancelik/herdr/SKILL.md

--- a/.claude/skills/publishing-k3s-apps/SKILL.md
+++ b/.claude/skills/publishing-k3s-apps/SKILL.md
@@ -9,12 +9,12 @@ description: Use when deploying a new app to the local k3s cluster (yuno04) or e
 
 yuno04のk3sはCloudflare Tunnel（`yuno-k3s`）で公開済み。Tunnelはcatch-allで全トラフィックを `http://traefik.kube-system:80` に転送し、TraefikがHostヘッダで各アプリのIngressに振り分ける。**アプリ追加時にTunnel設定の変更は不要**。必要なのは「k8sマニフェスト適用」と「DNSレコード追加（Terraform経由）」だけ。
 
-構成一式は private repo [`karia/yuno04-k3s`](https://github.com/karia/yuno04-k3s)（ローカル `~/k3s`）、DNSは別repo [`karia/side2.net`](https://github.com/karia/side2.net) の `terraform/dns/` で管理。
+構成一式は private repo [`karia/yuno04-k3s`](https://github.com/karia/yuno04-k3s)（ローカル `~/ghq/github.com/karia/yuno04-k3s`、ghq管理）、DNSは別repo [`karia/side2.net`](https://github.com/karia/side2.net) の `terraform/dns/` で管理。
 
 ## 手順
 
-1. マニフェストを `~/k3s/apps/<アプリ名>/` に作成（下の例を参照）
-2. `kubectl apply -R -f ~/k3s/apps/<アプリ名>/`
+1. マニフェストを `~/ghq/github.com/karia/yuno04-k3s/apps/<アプリ名>/` に作成（下の例を参照）
+2. `kubectl apply -R -f ~/ghq/github.com/karia/yuno04-k3s/apps/<アプリ名>/`
 3. DNS登録: `karia/side2.net` の `terraform/dns/records.tf` に proxied CNAME を追加 → **PR作成 → レビュー → マージ後にローカルで `terraform apply`**（レコードはこの apply で作成される）
 4. 検証: `kubectl rollout status deploy/<アプリ名>` → `curl -s https://<ホスト名>.side2.net` で期待するレスポンスを確認
 
@@ -76,7 +76,7 @@ spec:
             backend: {service: {name: myapp, port: {number: 80}}}
 ```
 
-実例: `~/k3s/apps/nginx/`（稼働中の `yuno04.side2.net`）
+実例: `~/ghq/github.com/karia/yuno04-k3s/apps/nginx/`（稼働中の `yuno04.side2.net`）
 
 ## Quick Reference
 
@@ -85,7 +85,7 @@ spec:
 | DNS管理 | `karia/side2.net` の `terraform/dns/records.tf` に追記 → PR → `terraform apply` |
 | Tunnel ID（CNAME content） | `records.tf` の既存レコードから引用、または `cloudflared tunnel list` / Cloudflare APIで取得 |
 | Cloudflare APIトークン / ID類 | `~/.config/cloudflare/token`, `~/.config/cloudflare/config` |
-| cloudflared本体 | namespace `cloudflared`（`~/k3s/cloudflared/`） |
+| cloudflared本体 | namespace `cloudflared`（`~/ghq/github.com/karia/yuno04-k3s/cloudflared/`） |
 | Tunnel設定 | catch-all固定。触らない |
 
 ## Common Mistakes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,12 +33,12 @@ The dotfiles expect the following tools to be available:
 Two deployment methods are supported:
 
 1. **Automated (macOS)**: Use the setup script at <https://github.com/karia/setup-mac>
-2. **Manual**: Clone the repository and create symlinks:
+2. **Manual**: Clone the repository under ghq and create symlinks:
 
    ```bash
+   ghq get karia/dot-files   # => ~/ghq/github.com/karia/dot-files
    cd ~
-   git clone git@github.com:karia/dot-files.git
-   ln -s ~/dot-files/.* .
+   ln -s ~/ghq/github.com/karia/dot-files/.* .
    ```
 
 ### Git Configuration
@@ -51,8 +51,8 @@ The repository uses Git's `includeIf` feature to automatically apply different c
 After cloning, create symlinks for the Git config files:
 
 ```bash
-ln -sf ~/dot-files/.gitconfig-work ~/.gitconfig-work
-ln -sf ~/dot-files/.gitconfig-personal ~/.gitconfig-personal
+ln -sf ~/ghq/github.com/karia/dot-files/.gitconfig-work ~/.gitconfig-work
+ln -sf ~/ghq/github.com/karia/dot-files/.gitconfig-personal ~/.gitconfig-personal
 ```
 
 ## Architecture Notes

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Use this script: https://github.com/karia/setup-mac
 ## Usage (Manual deploy)
 
 ```
-cd ~
-git clone git@github.com:karia/dot-files.git
+ghq get karia/dot-files   # => ~/ghq/github.com/karia/dot-files
 
-ln -s ~/dot-files/.* .
+cd ~
+ln -s ~/ghq/github.com/karia/dot-files/.* .
 ```
 
 Sashimi Tampopo!!


### PR DESCRIPTION
Local checkout moved from `~/dot-files` to `~/ghq/github.com/karia/dot-files` (all home-dir symlinks re-pointed).

- Update deployment instructions (README / CLAUDE.md) to the ghq-based path
- Track `.claude/skills/herdr/SKILL.md` symlink (absolute path into the ghq-managed herdr repo; dangling on machines without that clone)
- Update publishing-k3s-apps skill paths after the yuno04-k3s ghq migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeYbRTirCPm53VRANcrfyC