### PR TITLE
Pin Claude Code model to claude-opus-5

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -56,6 +56,7 @@
       "Bash(git push -f:*)"
     ]
   },
+  "model": "claude-opus-5",
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
Adds a `model` pin to `.claude/settings.json` so new sessions start on Opus 5.