### PR TITLE
Sync .gitignore entries from dot-claude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,15 @@
 .claude/.update.lock
 .claude/backups/
 .claude/cache/
+.claude/commands/
+.claude/daemon.log
+.claude/daemon/
 .claude/debug/
 .claude/file-history/
 .claude/history.jsonl
 .claude/ide/
+.claude/image-cache/
+.claude/jobs/
 .claude/mcp-needs-auth-cache.json
 .claude/paste-cache/
 .claude/plans/

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,18 @@
 .claude/sessions/
 .claude/settings.local.json
 .claude/shell-snapshots/
+# AWS Well-Architectedのskill群はaws-samplesリポジトリへのsymlinkでマシンローカル。symlinkはディレクトリ扱いされず末尾スラッシュ付きだとマッチしないため付けない
+.claude/skills/architecture-decision-record
+.claude/skills/cost-optimization-review
+.claude/skills/migration-readiness
+.claude/skills/operational-excellence
+.claude/skills/performance-efficiency
+.claude/skills/reliability-improvement-plan
+.claude/skills/security-assessment
+.claude/skills/sustainability-optimization
+.claude/skills/wa-builder
+.claude/skills/wa-guardrails
+.claude/skills/wa-review
 .claude/stats-cache.json
 .claude/statsig/
 .claude/tasks/


### PR DESCRIPTION
Align `.gitignore` with `karia/dot-claude` so the two Claude Code configs stop drifting.

- Claude Code runtime dirs (`commands/`, `daemon.log`, `daemon/`, `image-cache/`, `jobs/`)
- AWS Well-Architected skill symlinks

First step of a wider dot-claude / dot-files sync; `CLAUDE.md` and `settings.json` follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WE3UYrXFo3gEphtqbstCR5