### PR TITLE
Add Rancher Desktop bin to PATH when installed

### DIFF
--- a/.zshenv
+++ b/.zshenv
@@ -61,6 +61,9 @@ if [[ -d "${HOME}/Library/pnpm/bin" ]]; then
   add_path_if_exists "$PNPM_HOME/bin"
 fi
 
+# Rancher Desktop: docker/nerdctl/kubectl when the app is installed
+add_path_if_exists "${HOME}/.rd/bin"
+
 # kubectl: k3s bundles kubectl as a symlink that defaults to the root-only
 # /etc/rancher/k3s/k3s.yaml, so point it at the user copy when one exists.
 [[ -f "${HOME}/.kube/config" ]] && export KUBECONFIG="${HOME}/.kube/config"


### PR DESCRIPTION
## Summary
- Add `~/.rd/bin` via `add_path_if_exists` in `.zshenv` so Rancher Desktop CLIs are on PATH only when installed
- Prefer this over Rancher Desktop's auto-written `.zshrc` block (hardcoded path, interactive-only)

## Test plan
- [ ] With `~/.rd/bin` present, new shell resolves `docker` / `nerdctl` from that path
- [ ] Without `~/.rd/bin`, shell starts cleanly and PATH is unchanged


Made with [Cursor](https://cursor.com)