### PR TITLE
Install the Bitwarden CLIs via mise

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,4 +1,6 @@
 [tools]
+bitwarden = "latest"
+bitwarden-secrets-manager = "latest"
 claude = "latest"
 fzf = "latest"
 ghq = "latest"

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@
 .claude/telemetry/
 .claude/todos/
 .claude/uploads/
+.config/Bitwarden CLI/
 .config/Code/
 .config/cloudflare/
 .config/configstore/


### PR DESCRIPTION
Groundwork for [side2.net ADR 0016](https://github.com/karia/side2.net/blob/main/docs/adr/0016-secrets-with-bitwarden-secrets-manager.md): `bws` reads the secrets that currently sit as plaintext files on yuno04, and `bw` is for interactive use.

Both come from the mise registry as native binaries (`aqua:bitwarden/clients` and `aqua:bitwarden/sdk-sm`) — no npm runtime involved. Verified `bw 2026.7.0` and `bws 2.1.0` both run on this host.

The `.gitignore` entry matters because this repo is public: `bw` writes `~/.config/Bitwarden CLI/data.json` on first run, which would otherwise sit untracked next to tracked config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7ibqRdyNFfad4avNCG4Yu