### PR TITLE
Allow EnterWorktree and ExitWorktree tools without prompting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,7 +48,8 @@
       "Bash(tflint:*)",
       "Bash(trivy:*)",
       "Bash(yamllint:*)",
-      "EnterWorktree"
+      "EnterWorktree",
+      "ExitWorktree"
     ],
     "deny": [],
     "ask": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,7 +47,8 @@
       "Bash(terraform validate:*)",
       "Bash(tflint:*)",
       "Bash(trivy:*)",
-      "Bash(yamllint:*)"
+      "Bash(yamllint:*)",
+      "EnterWorktree"
     ],
     "deny": [],
     "ask": [

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@
 .claude/telemetry/
 .claude/todos/
 .claude/uploads/
+.claude/worktrees/
 .config/Bitwarden CLI/
 .config/Code/
 .config/cloudflare/


### PR DESCRIPTION
Adds `EnterWorktree` and `ExitWorktree` to `permissions.allow` so worktree isolation no longer needs a prompt each session.

Also gitignores `.claude/worktrees/`, the directory `EnterWorktree` creates — it was only covered by the untracked `.git/info/exclude`.

Note: `ExitWorktree` with `action: "remove"` deletes the worktree directory and its branch. It refuses when there are uncommitted files or unmerged commits unless `discard_changes: true` is passed, so the destructive path is not fully unguarded, but it is no longer prompted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125dwBPYpU1A9XuL89Rts91